### PR TITLE
Add additional usage example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,36 @@ To forcibly rebuilt every files, use the ``--force`` option::
 
     python setup.py build_ui --force
 
+If you want to require the user to have ``pyqt-distutils`` installed, and
+always have the ``build_ui`` command run as part of the ``develop`` and
+``install`` commands, you can do so with two custom command classes:
+
+.. code-block:: python
+
+    from setuptools import setup
+    from setuptools.command.develop import develop
+    from setuptools.command.install import install
+
+    from pyqt_distutils.build_ui import build_ui
+
+    class custom_develop(develop):
+        def run(self):
+            self.run_command('build_ui')
+            develop.run(self)
+
+    class custom_install(install):
+        def run(self):
+            self.run_command('build_ui')
+            install.run(self)
+
+    setup(...,
+        cmdclass={
+            'build_ui': build_ui,
+            'develop': custom_develop,
+            'install': custom_install
+        }
+    )
+
 UI Files
 --------
 


### PR DESCRIPTION
The example shows how to have `build_ui` always run as part of the `develop` and `install` commands.