### PR TITLE
Add optional support for colorama

### DIFF
--- a/.hackedit/config.py
+++ b/.hackedit/config.py
@@ -1,0 +1,95 @@
+# The default ``config.py``
+
+
+def set_prefs(prefs):
+    """This function is called before opening the project"""
+
+    # Specify which files and folders to ignore in the project.
+    # Changes to ignored resources are not added to the history and
+    # VCSs.  Also they are not returned in `Project.get_files()`.
+    # Note that ``?`` and ``*`` match all characters but slashes.
+    # '*.pyc': matches 'test.pyc' and 'pkg/test.pyc'
+    # 'mod*.pyc': matches 'test/mod1.pyc' but not 'mod/1.pyc'
+    # '.svn': matches 'pkg/.svn' and all of its children
+    # 'build/*.o': matches 'build/lib.o' but not 'build/sub/lib.o'
+    # 'build//*.o': matches 'build/lib.o' and 'build/sub/lib.o'
+    prefs['ignored_resources'] = ['*.pyc', '*~', '.ropeproject',
+                                  '.hg', '.svn', '_svn', '.git', '.tox']
+
+    # Specifies which files should be considered python files.  It is
+    # useful when you have scripts inside your project.  Only files
+    # ending with ``.py`` are considered to be python files by
+    # default.
+    #prefs['python_files'] = ['*.py']
+
+    # Custom source folders:  By default rope searches the project
+    # for finding source folders (folders that should be searched
+    # for finding modules).  You can add paths to that list.  Note
+    # that rope guesses project source folders correctly most of the
+    # time; use this if you have any problems.
+    # The folders should be relative to project root and use '/' for
+    # separating folders regardless of the platform rope is running on.
+    # 'src/my_source_folder' for instance.
+    #prefs.add('source_folders', 'src')
+
+    # You can extend python path for looking up modules
+    #prefs.add('python_path', '~/python/')
+
+    # Should rope save object information or not.
+    prefs['save_objectdb'] = True
+    prefs['compress_objectdb'] = False
+
+    # If `True`, rope analyzes each module when it is being saved.
+    prefs['automatic_soa'] = True
+    # The depth of calls to follow in static object analysis
+    prefs['soa_followed_calls'] = 0
+
+    # If `False` when running modules or unit tests "dynamic object
+    # analysis" is turned off.  This makes them much faster.
+    prefs['perform_doa'] = True
+
+    # Rope can check the validity of its object DB when running.
+    prefs['validate_objectdb'] = True
+
+    # How many undos to hold?
+    prefs['max_history_items'] = 32
+
+    # Shows whether to save history across sessions.
+    prefs['save_history'] = True
+    prefs['compress_history'] = False
+
+    # Set the number spaces used for indenting.  According to
+    # :PEP:`8`, it is best to use 4 spaces.  Since most of rope's
+    # unit-tests use 4 spaces it is more reliable, too.
+    prefs['indent_size'] = 4
+
+    # Builtin and c-extension modules that are allowed to be imported
+    # and inspected by rope.
+    prefs['extension_modules'] = []
+
+    # Add all standard c-extensions to extension_modules list.
+    prefs['import_dynload_stdmods'] = True
+
+    # If `True` modules with syntax errors are considered to be empty.
+    # The default value is `False`; When `False` syntax errors raise
+    # `rope.base.exceptions.ModuleSyntaxError` exception.
+    prefs['ignore_syntax_errors'] = False
+
+    # If `True`, rope ignores unresolvable imports.  Otherwise, they
+    # appear in the importing namespace.
+    prefs['ignore_bad_imports'] = False
+
+    # If `True`, rope will transform a comma list of imports into
+    # multiple separate import statements when organizing
+    # imports.
+    prefs['split_imports'] = False
+
+    # If `True`, rope will sort imports alphabetically by module name
+    # instead of alphabetically by import statement, with from imports
+    # after normal imports.
+    prefs['sort_imports_alphabetically'] = False
+
+
+def project_opened(project):
+    """This function is called after opening the project"""
+    # Do whatever you like here!

--- a/.hackedit/config.usr
+++ b/.hackedit/config.usr
@@ -1,0 +1,4 @@
+{
+    "linked_paths": [],
+    "workspace": "Python"
+}

--- a/README.rst
+++ b/README.rst
@@ -216,6 +216,18 @@ This project is licensed under the MIT license.
 Changelog
 ---------
 
+0.7.0
++++++
+
+Add optional support for colorama.
+
+If colorama can be imported, the build_ui output will be colored as follow:
+
+- pyuic/pyrcc commands in GREEN
+- skipped targets with the DEFAULT FORE COLOR
+- warning message in YELLOW
+- error messages in RED
+
 0.6.2
 +++++
 

--- a/pyqt_distutils/__init__.py
+++ b/pyqt_distutils/__init__.py
@@ -5,4 +5,4 @@ A set of PyQt distutils extensions for build qt ui files in a pythonic way:
 
 """
 
-__version__ = '0.6.2'
+__version__ = '0.7.0'

--- a/pyqt_distutils/build_ui.py
+++ b/pyqt_distutils/build_ui.py
@@ -8,6 +8,8 @@ from setuptools import Command
 
 from .config import Config
 from .hooks import load_hooks
+from .utils import write_message
+
 
 class build_ui(Command):
     """
@@ -27,7 +29,7 @@ class build_ui(Command):
             self.cfg = Config()
             self.cfg.load()
         except (IOError, OSError):
-            print('cannot open pyuic.json (or pyuic.cfg)')
+            write_message('cannot open pyuic.json (or pyuic.cfg)', 'red')
             self.cfg = None
 
     def is_outdated(self, src, dst, ui):
@@ -62,7 +64,7 @@ class build_ui(Command):
         for glob_exp, dest in self.cfg.files:
             for src in glob.glob(glob_exp):
                 if not os.path.exists(src):
-                    print('skipping target %s, file not found' % src)
+                    write_message('skipping target %s, file not found' % src, 'yellow')
                     continue
                 src = os.path.join(os.getcwd(), src)
                 dst = os.path.join(os.getcwd(), dest)
@@ -86,15 +88,15 @@ class build_ui(Command):
                     pass
 
                 if self.is_outdated(src, dst, ui):
-                    print(cmd)
+                    write_message(cmd, 'green')
                     os.system(cmd)
                     for hookname in self.cfg.hooks:
                         try:
                             hook = self._hooks[hookname]
                         except KeyError:
-                            print('warning, unknonw hook: %r' % hookname)
+                            write_message('warning, unknonw hook: %r' % hookname, 'yellow')
                         else:
-                            print('running hook %r' % hookname)
+                            write_message('running hook %r' % hookname, 'blue')
                             hook(dst)
                 else:
-                    print('skipping %s, up to date' % src)
+                    write_message('skipping %s, up to date' % src)

--- a/pyqt_distutils/config.py
+++ b/pyqt_distutils/config.py
@@ -4,6 +4,7 @@ Contains the config class (pyuic.cfg or pyuic.json)
 """
 import json
 
+from .utils import write_message
 
 class QtApi:
     pyqt4 = 0
@@ -36,7 +37,7 @@ class Config:
             else:
                 break
         else:
-            print('failed to open configuration file')
+            write_message('failed to open configuration file', 'yellow')
         if not hasattr(self, 'hooks'):
             self.hooks = []
 
@@ -64,17 +65,17 @@ class Config:
             self.pyuic_options = '--from-import'
             self.files[:] = []
         self.save()
-        print('pyuic.json generated')
+        write_message('pyuic.json generated', 'green')
 
     def add(self, src, dst):
         self.load()
         for fn, _ in self.files:
             if fn == src:
-                print('ui file already added: %s' % src)
+                write_message('ui file already added: %s' % src)
                 return
         self.files.append((src, dst))
         self.save()
-        print('file added to pyuic.json: %s -> %s' % (src, dst))
+        write_message('file added to pyuic.json: %s -> %s' % (src, dst), 'green')
 
     def remove(self, filename):
         self.load()
@@ -87,4 +88,4 @@ class Config:
         if to_remove is not None:
             self.files.pop(to_remove)
         self.save()
-        print('file removed from pyuic.json: %s' % filename)
+        write_message('file removed from pyuic.json: %s' % filename, 'green')

--- a/pyqt_distutils/hooks.py
+++ b/pyqt_distutils/hooks.py
@@ -4,7 +4,8 @@ This module contains the hooks load and our builtin hooks.
 """
 import re
 import pkg_resources
-import traceback
+
+from .utils import write_message
 
 
 #: Name of the entrypoint to use in setup.py
@@ -23,8 +24,8 @@ def load_hooks():
         name = str(entrypoint).split('=')[0].strip()
         try:
             hook = entrypoint.load()
-        except Exception:
-            traceback.print_exc()
+        except Exception as e:
+            write_message('failed to load entry-point %r (error="%s")' % (name, e), 'yellow')
         else:
             hooks[name] = hook
     return hooks
@@ -35,7 +36,6 @@ def hook(ui_file_path):
     This is the prototype of a hook function.
     """
     pass
-
 
 
 def gettext(ui_file_path):

--- a/pyqt_distutils/utils.py
+++ b/pyqt_distutils/utils.py
@@ -1,0 +1,22 @@
+try:
+    import colorama
+except ImportError:
+    has_colorama = False
+else:
+    has_colorama = True
+
+
+def write_message(text, color=None):
+    if has_colorama:
+        colors = {
+            'red': colorama.Fore.RED,
+            'green': colorama.Fore.GREEN,
+            'yellow': colorama.Fore.YELLOW,
+            'blue': colorama.Fore.BLUE
+        }
+        try:
+            print(colors[color] + text + colorama.Fore.RESET)
+        except KeyError:
+            print(text)
+    else:
+        print(text)


### PR DESCRIPTION
If colorama can be imported, the build_ui output will be colored as follow:

- pyuic/pyrcc commands in GREEN
- skipped targets with the DEFAULT FORE COLOR
- warning message in YELLOW
- error messages in RED

Example:

![screenshot_20160619_184726](https://cloud.githubusercontent.com/assets/1681217/16178642/60089194-364e-11e6-9de5-831a8f926e0e.png)
