### PR TITLE
Handle paths with spaces

### DIFF
--- a/pyqt_distutils/build_ui.py
+++ b/pyqt_distutils/build_ui.py
@@ -4,15 +4,6 @@ Distutils extension for PyQt/PySide applications
 """
 import glob
 import os
-import shlex
-
-try:
-    # Python 3
-    from shlex import quote
-except ImportError:
-    # Python 2
-    from pipes import quote
-
 import subprocess
 import sys
 
@@ -20,7 +11,7 @@ from setuptools import Command
 
 from .config import Config
 from .hooks import load_hooks
-from .utils import write_message
+from .utils import build_args, write_message
 
 
 class build_ui(Command):
@@ -93,7 +84,6 @@ class build_ui(Command):
                 filename = os.path.split(src)[1]
                 filename = os.path.splitext(filename)[0]
                 dst = os.path.join(dst, filename + ext)
-                cmd = cmd % (quote(src), quote(dst))
                 try:
                     os.makedirs(os.path.split(dst)[0])
                 except OSError:
@@ -101,8 +91,7 @@ class build_ui(Command):
 
                 if self.is_outdated(src, dst, ui):
                     try:
-                        args = shlex.split(cmd)
-                        subprocess.check_call([arg for arg in args if arg])
+                        subprocess.check_call(build_args(cmd, src, dst))
                     except subprocess.CalledProcessError as e:
                         if e.output:
                             write_message(cmd, 'yellow')

--- a/pyqt_distutils/build_ui.py
+++ b/pyqt_distutils/build_ui.py
@@ -4,6 +4,15 @@ Distutils extension for PyQt/PySide applications
 """
 import glob
 import os
+import shlex
+
+try:
+    # Python 3
+    from shlex import quote
+except ImportError:
+    # Python 2
+    from pipes import quote
+
 import subprocess
 import sys
 
@@ -84,7 +93,7 @@ class build_ui(Command):
                 filename = os.path.split(src)[1]
                 filename = os.path.splitext(filename)[0]
                 dst = os.path.join(dst, filename + ext)
-                cmd = cmd % (src, dst)
+                cmd = cmd % (quote(src), quote(dst))
                 try:
                     os.makedirs(os.path.split(dst)[0])
                 except OSError:
@@ -92,7 +101,8 @@ class build_ui(Command):
 
                 if self.is_outdated(src, dst, ui):
                     try:
-                        subprocess.check_call([t for t in cmd.split(' ') if t])
+                        args = shlex.split(cmd)
+                        subprocess.check_call([arg for arg in args if arg])
                     except subprocess.CalledProcessError as e:
                         if e.output:
                             write_message(cmd, 'yellow')

--- a/pyqt_distutils/utils.py
+++ b/pyqt_distutils/utils.py
@@ -5,6 +5,27 @@ except ImportError:
 else:
     has_colorama = True
 
+import shlex
+try:
+    # Python 3
+    from shlex import quote
+except ImportError:
+    # Python 2
+    from pipes import quote
+
+def build_args(cmd, src, dst):
+    """
+        Build arguments list for passing to subprocess.call_check
+
+        :param cmd str: Command string to interpolate src and dst filepaths into.
+            Typically the output of `config.Config.uic_command` or `config.Config.rcc_command`.
+        :param src str: Source filepath.
+        :param dst str: Destination filepath.
+    """
+    cmd = cmd % (quote(src), quote(dst))
+    args = shlex.split(cmd)
+
+    return [arg for arg in args if arg]
 
 def write_message(text, color=None):
     if has_colorama:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,47 @@
+import unittest
+
+from pyqt_distutils.utils import build_args
+
+class CreateDatabaseTest(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_build_args(self):
+        """
+            Basic argument building test with build_args method.
+        """
+        cmd = 'python -m PyQt5.uic.pyuic --from-import %s -o %s'
+        src = '/path/a'
+        dst = '/path/b'
+
+        args = build_args(cmd, src, dst)
+        expected = ['python', '-m', 'PyQt5.uic.pyuic', '--from-import', '/path/a', '-o', '/path/b']
+        self.assertListEqual(args, expected)
+
+    def test_build_args_empty_token_removal(self):
+        """
+            Argument building test for removal of empty tokens with build_args method.
+
+            Test for regression of: https://github.com/ColinDuquesnoy/pyqt_distutils/issues/7
+        """
+        cmd = 'pyrcc5  %s -o %s'
+        src = '/path/a'
+        dst = '/path/b'
+
+        args = build_args(cmd, src, dst)
+        expected = ['pyrcc5', '/path/a', '-o', '/path/b']
+        self.assertListEqual(args, expected)
+
+    def test_build_args_paths_with_spaces(self):
+        """
+            Argument building test for paths with spaces using build_args method.
+
+            Test for regression of: https://github.com/ColinDuquesnoy/pyqt_distutils/pull/9
+        """
+        cmd = 'python -m PyQt5.uic.pyuic --from-import %s -o %s'
+        src = '/path/a space/path'
+        dst = '/path/b space/path'
+
+        args = build_args(cmd, src, dst)
+        expected = ['python', '-m', 'PyQt5.uic.pyuic', '--from-import', '/path/a space/path', '-o', '/path/b space/path']
+        self.assertListEqual(args, expected)


### PR DESCRIPTION
Without this change paths or files containing spaces would be split as separate arguments, which would result in a failure to the call of PyQt5.pyrcc_main e.g.:

    PyQt5/pyrcc_main.py: File does not exist "/Users/xxx/path_before_space"

Where the rest of the path after the space is treated as the next argument and hence results in a 'File does not exist' error.

The fix is achieved by quoting the strings used for filepaths when building the command to run and then using shlex to split instead of only splitting on spaces.

This pull request has been tested on Mac OS X. It should behave the same on Linux as Mac OS X and as far as I can tell it should also work fine on Windows with the `if sys.platform == 'win32':` code path.